### PR TITLE
add error/bounds checking on NewHex with tests

### DIFF
--- a/color.go
+++ b/color.go
@@ -145,21 +145,41 @@ func NewBgRGB(r, g, b uint8, value ...Attribute) *Color {
 }
 
 // NewHex returns a newly created foreground color object from given hex color; e.g #7fe9a2
-func NewHex(h string, value ...Attribute) *Color {
+func NewHex(h string, value ...Attribute) (*Color, error) {
 	r, g, b, err := hexToRGB(h)
+	if err != nil {
+		return nil, err
+	}
+	return NewRGB(r, g, b, value...), nil
+}
+
+// MustNewHex returns a newly created foreground color object from given hex color; e.g #7fe9a2
+// MustNewHex will panic if it receives an invalid hex color
+func MustNewHex(h string, value ...Attribute) *Color {
+	color, err := NewHex(h, value...)
 	if err != nil {
 		panic(err)
 	}
-	return NewRGB(r, g, b, value...)
+	return color
 }
 
 // NewBgHex returns a newly created background color object from given hex color; e.g #7fe9a2
-func NewBgHex(h string, value ...Attribute) *Color {
+func NewBgHex(h string, value ...Attribute) (*Color, error) {
 	r, g, b, err := hexToRGB(h)
+	if err != nil {
+		return nil, err
+	}
+	return NewBgRGB(r, g, b, value...), nil
+}
+
+// MustNewBgHex returns a newly created background color object from given hex color; e.g #7fe9a2
+// MustNewBgHex will panic if it receives an invalid hex color
+func MustNewBgHex(h string, value ...Attribute) *Color {
+	color, err := NewBgHex(h, value...)
 	if err != nil {
 		panic(err)
 	}
-	return NewBgRGB(r, g, b, value...)
+	return color
 }
 
 // Merge combines the Attributes of two Colors, typically a foreground and background
@@ -658,8 +678,10 @@ func HiWhiteString(format string, a ...interface{}) string {
 }
 
 func hexToRGB(h string) (r, g, b uint8, err error) {
-	if string(h[0]) == "#" {
-		h = h[1:]
+	if len(h) > 2 {
+		if string(h[0]) == "#" {
+			h = h[1:]
+		}
 	}
 
 	if len(h) == 3 {
@@ -672,8 +694,14 @@ func hexToRGB(h string) (r, g, b uint8, err error) {
 		return
 	}
 
-	r = uint8(hb[0])
-	g = uint8(hb[1])
-	b = uint8(hb[2])
+	if len(hb) > 0 {
+		r = uint8(hb[0])
+	}
+	if len(hb) > 1 {
+		g = uint8(hb[1])
+	}
+	if len(hb) > 2 {
+		b = uint8(hb[2])
+	}
 	return
 }

--- a/color_test.go
+++ b/color_test.go
@@ -340,3 +340,35 @@ func TestNoFormatString(t *testing.T) {
 		}
 	}
 }
+
+func TestNewHex(t *testing.T) {
+	// empty string
+	color := MustNewHex("")
+	if !color.Equals(MustNewHex("#000000")) {
+		t.Errorf("empty string should return black")
+	}
+	// short string
+	color = MustNewHex("#FF")
+	if !color.Equals(MustNewHex("#FF0000")) {
+		t.Errorf("#FF should return red")
+	}
+	// long string
+	color = MustNewHex("#FFFFFFFFFF")
+	if !color.Equals(MustNewHex("#FFFFFF")) {
+		t.Errorf("repeated F should return white")
+	}
+	// invalid
+	_, err := NewHex("#YYYYYY")
+	if err == nil {
+		t.Errorf("invalid hex should return error")
+	}
+	// odd length
+	_, err = NewHex("#F")
+	if err == nil {
+		t.Errorf("odd length hex should return error")
+	}
+	_, err = NewHex("#FFFFF")
+	if err == nil {
+		t.Errorf("odd length hex should return error")
+	}
+}


### PR DESCRIPTION
This changes the signature of `NewHex` and `NewBgHex` to return an error when parsing hex codes as well as implementing bounds checking in the internal `hexToRGB` function.  

The new error signatures should be more convenient for API consumers rather than causing a panic or forcing the caller to implement checking outside of the package. Arguably we could revert the new signatures and add an additional function like `ValidateHex` leaving the responsibility to the caller.

The `hexToRGB` function also now allows for partial hex codes such as `#00` or `#00FF` which is the same as the Go stdlib package and will propagate all encountered errors upwards. 

Thanks!